### PR TITLE
Made PouchDB server name and host configurable

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -14,3 +14,6 @@ PORT=5678
 # Get these values from https://github.com/organizations/hellomouse/settings/apps/notification-service at the bottom of the page
 CLIENT_ID='';
 CLIENT_SECRET='';
+
+POUCH_REMOTE='http://91.92.144.105:5984/gns'
+HOST='' # URL for the redirect for the GitHub login

--- a/bot/index.js
+++ b/bot/index.js
@@ -4,7 +4,7 @@ const IRC = require('./irc');
 const web = require('./web');
 const { Application } = require('probot'); // eslint-disable-line no-unused-vars
 const PouchDB = require('pouchdb');
-const db = new PouchDB('http://91.92.144.105:5984/gns');
+const db = new PouchDB(process.env.POUCH_REMOTE);
 
 let pendingStatus = []; // contains all pending checks from travis as multiple are sent
 

--- a/bot/irc.js
+++ b/bot/irc.js
@@ -7,7 +7,7 @@ const { Application } = require('probot'); // eslint-disable-line no-unused-vars
 const PouchDB = require('pouchdb');
 
 // Config DB
-const db = new PouchDB('http://91.92.144.105:5984/gns');
+const db = new PouchDB(process.env.POUCH_REMOTE);
 
 /**
 * Strips formatting from IRC messages

--- a/bot/web.js
+++ b/bot/web.js
@@ -11,7 +11,6 @@ const fs = require('fs');
 const jwt = require('jsonwebtoken');
 const key = fs.readFileSync('./private-key.pem').toString();
 
-process.env.HOST = 'http://wolfy1339.ddns.net:5678';
 const redirect_uri = `${process.env.HOST}/redirect`;
 
 const headers = {
@@ -89,7 +88,7 @@ module.exports = async function web(app) {
     const { data: emails } = await octokit.users.getEmails();
     const { data: orgs } = await octokit.users.getOrgs();
 
-    const db = new PouchDB('http://91.92.144.105:5984/GNS');
+    const db = new PouchDB(process.env.POUCH_REMOTE);
     const defaults = {
       enabled: true
     };


### PR DESCRIPTION
I replaced hardcoded PouchDB name and HOST (used for redirects) with environmental variables.