### PR TITLE
Convert eslint config to tslint 🎉 

### DIFF
--- a/bot/tslint.json
+++ b/bot/tslint.json
@@ -1,27 +1,135 @@
 {
-    "defaultSeverity": "error",
-    "extends": [
-        "tslint:recommended"
+  "defaultSeverity": "error",
+  "extends": [
+    "tslint:recommended",
+    "tslint-eslint-rules"
+  ],
+  "jsRules": {},
+  "rules": {
+    "object-literal-sort-keys": false,
+    "max-line-length": [true, {
+      "limit": 120,
+      "ignore-pattern": "//"
+    }],
+    "prefer-const": false,
+    "one-variable-per-declaration": false,
+    "jsdoc-format": false,
+    "ordered-imports": false,
+    "quotemark": [true, "single", "avoid-escape", "avoid-template"],
+    "arrow-parens": [true, "ban-single-arg-parens"],
+    "trailing-comma": [
+      true,
+      {
+        "multiline": "never",
+        "singleline": "never"
+      }
     ],
-    "jsRules": {},
-    "rules": {
-      "object-literal-key-quotes": [true, "as-needed"],
-      "quotemark": [true, "single", "avoid-escape", "avoid-template"],
-      "curly": false,
-      "arrow-parens": [true, "ban-single-arg-parens"],
-      "prefer-const": false,
-      "trailing-comma": [true, "never"],
-      "interface-name": false,
-      "max-classes-per-file": false,
-      "ordered-imports": false,
-      "jsdoc-format": false,
-      "object-literal-sort-keys": false,
-      "member-access": false,
-      "no-empty": false,
-      "variable-name": false,
-      "array-type": false,
-      "max-line-length": [true, {"limit": 120, "ignore-pattern": "//"}],
-      "one-variable-per-declaration": false
+    "ter-padded-blocks": [
+      "error",
+      {
+        "blocks": "never"
+      }
+    ],
+    "ter-arrow-parens": [
+      true,
+      "as-needed"
+    ],
+    "one-variable-per-eclaration": false,
+    "variable-name": [
+      true,
+      "allow-leading-underscore",
+      "allow-pascal-case"
+    ],
+    "ter-max-len": [
+      "error",
+      {
+        "code": 120,
+        "tabWidth": 4,
+        "ignoreComments": true,
+        "ignoreTrailingComments": true,
+        "ignoreUrls": true
+      }
+    ],
+    "curly": [
+      true,
+      "ignore-same-line"
+    ],
+    "block-spacing": [
+      true,
+      "always"
+    ],
+    "brace-style": [
+      true,
+      "1tbs",
+      {
+        "allowSingleLine": true
+      }
+    ],
+    "object-curly-spacing": [
+      true,
+      "always"
+    ],
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "no-duplicate-variable": true,
+    "no-shadowed-variable": true,
+    "no-conditional-assignment": true,
+    "object-literal-key-quotes": [
+      true,
+      "as-needed"
+    ],
+    "semicolon": true,
+    "prefer-template": true,
+    "ter-newline-after-var": [true, "always"],
+    "no-unexpected-multiline": true,
+    "valid-jsdoc": [true, {
+      "requireParamDescription": false,
+      "requireReturnDescription": false,
+      "requireReturn": false,
+      "prefer": {
+        "returns": "return"
+      }
+    }],
+    "no-arg": true,
+    "no-multi-spaces": true,
+    "no-construct": true,
+    "no-string-throw": true,
+    "array-bracket-spacing": [true, "never"],
+    "ter-computed-property-spacing": [true],
+    "eofline": true,
+    "ter-func-call-spacing": true,
+    "ter-indent": [
+      true, 2, {
+        "CallExpression": {
+          "arguments": 2
+        },
+        "FunctionDeclaration": {
+          "body": 1,
+          "parameters": 2
+        },
+        "FunctionExpression": {
+          "body": 1,
+          "parameters": 2
+        },
+        "MemberExpression": 2,
+        "ObjectExpression": 1,
+        "SwitchCase": 1,
+        "ignoredNodes": [
+          "ConditionalExpression"
+        ]
+      }
+    ],
+    "linebreak-style": [true, "LF"],
+    "ter-no-mixed-spaces-and-tabs": {
+      "type": "spaces"
+    },
+    "no-consecutive-blank-lines": [true, 2],
+    "ter-no-tabs": true,
+    "no-trailing-whitespace": [true, "ignore-template-strings"],
+    "comment-format": [true, "check-space"],
+    "no-var-keyword": true
   },
-    "rulesDirectory": []
+  "rulesDirectory": []
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "nodemon": "^1.18.7",
     "smee-client": "^1.0.2",
     "tslint": "^5.11.0",
+    "tslint-eslint-rules": "^5.4.0",
     "typescript": "^3.1.6"
   },
   "engines": {

--- a/tslint.json
+++ b/tslint.json
@@ -1,28 +1,135 @@
 {
-    "defaultSeverity": "error",
-    "extends": [
-        "tslint:recommended"
+  "defaultSeverity": "error",
+  "extends": [
+    "tslint:recommended",
+    "tslint-eslint-rules"
+  ],
+  "jsRules": {},
+  "rules": {
+    "object-literal-sort-keys": false,
+    "max-line-length": [true, {
+      "limit": 120,
+      "ignore-pattern": "//"
+    }],
+    "prefer-const": false,
+    "one-variable-per-declaration": false,
+    "jsdoc-format": false,
+    "ordered-imports": false,
+    "quotemark": [true, "single", "avoid-escape", "avoid-template"],
+    "arrow-parens": [true, "ban-single-arg-parens"],
+    "trailing-comma": [
+      true,
+      {
+        "multiline": "never",
+        "singleline": "never"
+      }
     ],
-    "jsRules": {},
-    "rules": {
-      "object-literal-key-quotes": [true, "as-needed"],
-      "quotemark": [true, "single", "avoid-escape", "avoid-template"],
-      "curly": false,
-      "arrow-parens": [true, "ban-single-arg-parens"],
-      "prefer-const": false,
-      "trailing-comma": [true, "never"],
-      "interface-name": false,
-      "max-classes-per-file": false,
-      "ordered-imports": false,
-      "jsdoc-format": false,
-      "object-literal-sort-keys": false,
-      "member-access": false,
-      "no-empty": false,
-      "variable-name": false,
-      "array-type": false,
-      "max-line-length": [true, {"limit": 120, "ignore-pattern": "//"}],
-      "one-variable-per-declaration": false,
-      "comment-format": false
+    "ter-padded-blocks": [
+      "error",
+      {
+        "blocks": "never"
+      }
+    ],
+    "ter-arrow-parens": [
+      true,
+      "as-needed"
+    ],
+    "one-variable-per-eclaration": false,
+    "variable-name": [
+      true,
+      "allow-leading-underscore",
+      "allow-pascal-case"
+    ],
+    "ter-max-len": [
+      "error",
+      {
+        "code": 120,
+        "tabWidth": 4,
+        "ignoreComments": true,
+        "ignoreTrailingComments": true,
+        "ignoreUrls": true
+      }
+    ],
+    "curly": [
+      true,
+      "ignore-same-line"
+    ],
+    "block-spacing": [
+      true,
+      "always"
+    ],
+    "brace-style": [
+      true,
+      "1tbs",
+      {
+        "allowSingleLine": true
+      }
+    ],
+    "object-curly-spacing": [
+      true,
+      "always"
+    ],
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "no-duplicate-variable": true,
+    "no-shadowed-variable": true,
+    "no-conditional-assignment": true,
+    "object-literal-key-quotes": [
+      true,
+      "as-needed"
+    ],
+    "semicolon": true,
+    "prefer-template": true,
+    "ter-newline-after-var": [true, "always"],
+    "no-unexpected-multiline": true,
+    "valid-jsdoc": [true, {
+      "requireParamDescription": false,
+      "requireReturnDescription": false,
+      "requireReturn": false,
+      "prefer": {
+        "returns": "return"
+      }
+    }],
+    "no-arg": true,
+    "no-multi-spaces": true,
+    "no-construct": true,
+    "no-string-throw": true,
+    "array-bracket-spacing": [true, "never"],
+    "ter-computed-property-spacing": [true],
+    "eofline": true,
+    "ter-func-call-spacing": true,
+    "ter-indent": [
+      true, 2, {
+        "CallExpression": {
+          "arguments": 2
+        },
+        "FunctionDeclaration": {
+          "body": 1,
+          "parameters": 2
+        },
+        "FunctionExpression": {
+          "body": 1,
+          "parameters": 2
+        },
+        "MemberExpression": 2,
+        "ObjectExpression": 1,
+        "SwitchCase": 1,
+        "ignoredNodes": [
+          "ConditionalExpression"
+        ]
+      }
+    ],
+    "linebreak-style": [true, "LF"],
+    "ter-no-mixed-spaces-and-tabs": {
+      "type": "spaces"
+    },
+    "no-consecutive-blank-lines": [true, 2],
+    "ter-no-tabs": true,
+    "no-trailing-whitespace": [true, "ignore-template-strings"],
+    "comment-format": [true, "check-space"],
+    "no-var-keyword": true
   },
-    "rulesDirectory": []
+  "rulesDirectory": []
 }


### PR DESCRIPTION
Using the `tslint-eslint-rules` package, most of our eslint rules are capable of being enforced on ts files.

It's not perfect, there are some bugs, but it is better than no linting at all